### PR TITLE
get_private_album_set: don't free result set while still looping over it

### DIFF
--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -1081,7 +1081,7 @@ function get_private_album_set($aid_str="")
 
     if ($result->numRows()) {
 
-        while ( ($album = $result->fetchAssoc(true)) ) {
+        while ( ($album = $result->fetchAssoc()) ) {
             $FORBIDDEN_SET_DATA[] = $album['aid'];
         } // while
 


### PR DESCRIPTION
fetchAssoc(true) calls $result->free which means that the loop ends after the first round. As a result, only the first private album ends up in $FORBIDDEN_SET_DATA, and all others are visible to the user.