### PR TITLE
Closing SQL connections and adding the persistent connection option

### DIFF
--- a/include/database/mysql/dbase.inc.php
+++ b/include/database/mysql/dbase.inc.php
@@ -98,6 +98,12 @@ class CPG_Dbase
 		return mysql_affected_rows($this->linkid);
 	}
 
+	public function __destruct()
+	{
+		if ($this->linkid) {
+			mysql_close($this->linkid);
+		}
+	}
 }
 
 class CPG_DbaseResult

--- a/include/database/mysql/dbase.inc.php
+++ b/include/database/mysql/dbase.inc.php
@@ -26,7 +26,11 @@ class CPG_Dbase
 
 	public function __construct ($cfg)
 	{
-		$link = @mysql_connect($cfg['dbserver'], $cfg['dbuser'], $cfg['dbpass']);
+		if (!empty($cfg['dbpersist'])) {
+			$link = @mysql_pconnect($cfg['dbserver'], $cfg['dbuser'], $cfg['dbpass']);
+		} else {
+			$link = @mysql_connect($cfg['dbserver'], $cfg['dbuser'], $cfg['dbpass']);
+		}
 
 		if ($link) {
 			$this->linkid = $link;

--- a/include/database/mysqli/dbase.inc.php
+++ b/include/database/mysqli/dbase.inc.php
@@ -96,6 +96,12 @@ class CPG_Dbase
 		return $this->dbobj->affected_rows;
 	}
 
+	public function __destruct()
+	{
+		if ($this->dbobj && $this->connected) {
+			$this->dbobj->close();
+		}
+	}
 }
 
 class CPG_DbaseResult

--- a/include/database/mysqli/dbase.inc.php
+++ b/include/database/mysqli/dbase.inc.php
@@ -27,6 +27,7 @@ class CPG_Dbase
 		$sp = explode(':', $cfg['dbserver']);
 		if (empty($sp[1])) $sp[1] = null;
 		if (isset($cfg['dbport'])) $sp[1] = $cfg['dbport'];
+		if (!empty($cfg['dbpersist'])) $sp[0] = 'p:'.$sp[0];
 
 		// needed for PHP 8.1 and later
 		mysqli_report(MYSQLI_REPORT_OFF);

--- a/include/database/pdo/dbase.inc.php
+++ b/include/database/pdo/dbase.inc.php
@@ -36,7 +36,9 @@ class CPG_Dbase
 			if (!empty($cfg['dbcharset'])) {
 				$dsn .= ';charset='.$cfg['dbcharset'];
 			}
-			$db = new PDO($dsn, $cfg['dbuser'], $cfg['dbpass']);
+			$db = new PDO($dsn, $cfg['dbuser'], $cfg['dbpass'], [
+				PDO::ATTR_PERSISTENT => !empty($cfg['dbpersist']),
+			]);
 			$this->_instance = $db;
 			$this->connected = true;
 		} catch (PDOException $e) {

--- a/include/database/pdo/dbase.inc.php
+++ b/include/database/pdo/dbase.inc.php
@@ -104,6 +104,10 @@ class CPG_Dbase
 		return $this->stmt->rowCount();
 	}
 
+	public function __destruct()
+	{
+		$this->_instance = null;
+	}
 }
 
 class CPG_DbaseResult


### PR DESCRIPTION
It is important to close SQL connections properly.

In some cases, it may be useful to have a persistent connection, so it is good to have an option to allow this.