### PR TITLE
Deny access to an album according to the visibility field

### DIFF
--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -1306,6 +1306,17 @@ function get_pic_data($album, &$count, &$album_name, $limit1=-1, $limit2=-1, $se
     global $lang_common, $lang_meta_album_names, $lang_errors;
     global $RESTRICTEDWHERE;
 
+ // if we're viewing an specific album, the variable "$alb_id" will contain its Identificator; otherwise it will contain -1 and we do not apply any restriction
+	$alb_id = is_numeric($album) ? $album : ($cat < 0 ? -$cat : -1);
+	if ($alb_id > 0 && !GALLERY_ADMIN_MODE) {
+    	$result = cpg_db_query("SELECT visibility FROM {$CONFIG['TABLE_ALBUMS']} WHERE aid = {$alb_id}");
+    	list($visibility) = $result->fetchRow(true);       	
+        if ((($visibility > FIRST_USER_CAT) && ($visibility - FIRST_USER_CAT != USER_ID)) OR
+            (($visibility < FIRST_USER_CAT) && !in_array($visibility, $USER_DATA['groups']))) {
+            cpg_die(ERROR, $lang_errors['perm_denied'], __FILE__, __LINE__);
+        }    
+	}
+	
     static $album_name_keyword = '', $pic_count = null;
 
     $superCage = Inspekt::makeSuperCage();

--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -1310,9 +1310,9 @@ function get_pic_data($album, &$count, &$album_name, $limit1=-1, $limit2=-1, $se
 	$alb_id = is_numeric($album) ? $album : ($cat < 0 ? -$cat : -1);
 	if ($alb_id > 0 && !GALLERY_ADMIN_MODE) {
     	$result = cpg_db_query("SELECT visibility FROM {$CONFIG['TABLE_ALBUMS']} WHERE aid = {$alb_id}");
-    	list($visibility) = $result->fetchRow(true);       	
-        if ((($visibility > FIRST_USER_CAT) && ($visibility - FIRST_USER_CAT != USER_ID)) OR
-            (($visibility < FIRST_USER_CAT) && !in_array($visibility, $USER_DATA['groups']))) {
+    	list($visibility) = $result->fetchRow(true);   	
+        if ($visibility != 0 && (($visibility > FIRST_USER_CAT && $visibility - FIRST_USER_CAT != USER_ID) OR
+            ($visibility < FIRST_USER_CAT && !in_array($visibility, $USER_DATA['groups'])))) {
             cpg_die(ERROR, $lang_errors['perm_denied'], __FILE__, __LINE__);
         }    
 	}


### PR DESCRIPTION
Introduce some code at the beginning of the "get_pic_data" function to deny access to an album for the current user according to the "visibility" property. This way there's no chance to access an album that the current user should not see.

Previously when displaying thumbnails you still could see "linked pictures" (those linked via the ·keywords" field). Although CPG hides the link to albums with no permissions for the current user, it existed the possibility to watch them, by example writting the link in the address bar of the navigator, what I consider a "back door" to access to these restricted albums.