### PR TITLE
Fix SMF 2.1 bridge: registration link uses removed action=register (should be signup)

### DIFF
--- a/bridge/smf21.inc.php
+++ b/bridge/smf21.inc.php
@@ -96,7 +96,7 @@ if (isset($bridge_lookup)) {
 
             // Pages to redirect to
             $this->page = array(
-                'register' => '/index.php?action=register',
+                'register' => '/index.php?action=signup',
                 'editusers' => '/index.php?action=mlist',
                 'edituserprofile' => '/index.php?action=profile;u='
             );


### PR DESCRIPTION
## Problem
bridge/smf21.inc.php redirects registration to /index.php?action=register.
SMF 2.1 renamed that action to `signup`, so action=register returns HTTP 404
and the bridge's registration link is broken on every SMF 2.1 install.

## Fix
Point the register redirect at action=signup (SMF 2.1's registration action).

## Testing
On SMF 2.1.7: index.php?action=register returns 404; index.php?action=signup
serves the registration page. Confirmed the corrected link reaches the signup form.

Note: bridge/smf20.inc.php is unaffected — SMF 2.0 still uses action=register.